### PR TITLE
Basic lambda in Python deployed with Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ when HTTP GET'ed.
     Implemented in Python. Deployed with Pulumi in Python. Packaged as a simple zip without dependencies.
     Exposed using a Lambda URL.
 
+  * [basic-lambda-python-terraform](basiclambda/python/basic-lambda-python-terraform): 
+
+    Implemented in Python. Deployed with Terraform. Packaged as a simple zip without dependencies.
+    Exposed using a Lambda URL.
+
 #### Go
 
 * [basic-lambda-go-cdk](basiclambda/go/basic-lambda-go-cdk):

--- a/basiclambda/python/basic-lambda-python-terraform/.gitignore
+++ b/basiclambda/python/basic-lambda-python-terraform/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/basiclambda/python/basic-lambda-python-terraform/README.md
+++ b/basiclambda/python/basic-lambda-python-terraform/README.md
@@ -1,0 +1,52 @@
+# basic-lambda-python-terraform
+
+Implemented in Python. Deployed with Terraform. Packaged as a simple zip without dependencies.
+Exposed using a Lambda URL.
+
+
+# basic-lambda-go-pulumi
+
+Implemented in Go. Deployed with Pulumi in Terraform. Packaged as a simple zip without dependencies.
+Exposed using a Lambda URL.
+
+## Deploy
+
+```shell
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+## Invoke
+
+Use the `lambda_function_url` value from the deployment output.
+
+_or_
+
+Find it using:
+
+```shell
+export FN_URL=`terraform output -json | jq -r '.lambda_function_url.value'`
+echo $FN_URL
+```
+
+Then run a cURL command like:
+
+```shell
+curl $FN_URL
+```
+It should look something like:
+
+``` 
+❯ curl $FN_URL
+"hello world from basic-lambda-golang-pulumi"%   
+```
+
+
+## Destroy
+
+```shell
+terraform destroy
+```
+

--- a/basiclambda/python/basic-lambda-python-terraform/app/.gitignore
+++ b/basiclambda/python/basic-lambda-python-terraform/app/.gitignore
@@ -1,0 +1,1 @@
+handler.zip

--- a/basiclambda/python/basic-lambda-python-terraform/app/lambda_handler.py
+++ b/basiclambda/python/basic-lambda-python-terraform/app/lambda_handler.py
@@ -1,0 +1,10 @@
+import json
+
+print("Loading function")
+
+def lambda_handler(event, context):
+    print(f"Received event: {event}")
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Hello world from basic-lambda-python-terraform Lambda!')
+    }

--- a/basiclambda/python/basic-lambda-python-terraform/terraform/.terraform.lock.hcl
+++ b/basiclambda/python/basic-lambda-python-terraform/terraform/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.86.1"
+  hashes = [
+    "h1:IekGV22ML8NcKlhaAceeWdHdXAWfFLJYaslIEkpMHps=",
+    "zh:0c5901c55f9bc0d353c48aa29e08d7152055dd296f3b60e1fe1634af8a7d32e4",
+    "zh:26ddfc89d2a410492e31f1014bbf5388f871cb67d01e80255bde3e22a468e8a6",
+    "zh:380c57474796e680c4477c4a69810db9389ce2717ff2da8d0f06716247dd1295",
+    "zh:53bf6f567be4348ddd566792fccddd9db6104111e619aa4042afb594b9a5cc75",
+    "zh:575c41544fd4ac969d59ecdff66428583c228a20a4893d238414e932bb2f2dc0",
+    "zh:63d9473a2f55f4941e98cb2fcc7031b4266c1cdc40a8f96d52b7d29504984da3",
+    "zh:6ec72fbc68f608a4e947a0b1356b14791330a425b7ebd3125e8023693bb37ec8",
+    "zh:729a0853f9ca42b60993d6233b80e1fea52cc5c9401693cef83ade502f51e3e8",
+    "zh:750eda82a9bde02a999677cdeb1e6d69b0d7af783e8d629c813da9be3ee6d493",
+    "zh:90f70d5b31bdae6b7f3aee9b2b618168a32f434eb976b935d907c95271e7e692",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9cbf0464984b19a5a9027e8b03ebf1b56761c73f97171013b29f2d525ba91587",
+    "zh:aec08a2374a5cdaac3df3d6a39d98aaf58a3e0a500259b791a2dc5693280bc4b",
+    "zh:b638d8bd8ad11f14f7811696edcf744df07ea0f5c6033f59f3b325f921b7f54c",
+    "zh:bb862a4d11da06fff7c04978769cd100547bbf4735f64bfe2374b289e41a5147",
+  ]
+}

--- a/basiclambda/python/basic-lambda-python-terraform/terraform/main.tf
+++ b/basiclambda/python/basic-lambda-python-terraform/terraform/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "basic_lambda_python_terraform_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.lambda_function.function_name}"
+  retention_in_days = 14
+}
+
+data "aws_iam_policy_document" "lambda_logging" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_logging" {
+  name        = "basic_lambda_python_terraform_logging_policy"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+  policy      = data.aws_iam_policy_document.lambda_logging.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name               = "basic-lambda-python-terraform-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "archive_file" "function_archive" {
+  type        = "zip"
+  source_file = "../app/lambda_handler.py"
+  output_path = "../app/handler.zip"
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  filename      = "../app/handler.zip"
+  function_name = "basic-lambda-python-terraform"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "lambda_handler.lambda_handler"
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
+  runtime = "python3.13"
+}
+
+resource "aws_lambda_function_url" "lambda_function_url" {
+  function_name      = aws_lambda_function.lambda_function.function_name
+  authorization_type = "NONE"
+}
+
+output "lambda_function_url" {
+  value = aws_lambda_function_url.lambda_function_url.function_url
+  description = "The URL endpoint for the Lambda function"
+}
+


### PR DESCRIPTION
Added the next basic lambda: Implemented in Python, deployed with Terraform, packaged as a simple zip without dependencies. Exposed using a Lambda URL.

Returns a "Hello world from basic-lambda-python-terraform Lambda!" message
when HTTP GET'ed.